### PR TITLE
Fixed notification settings hiding when notifications turned off

### DIFF
--- a/app/src/main/java/com/johnston/lmhapp/SetupLogIn.java
+++ b/app/src/main/java/com/johnston/lmhapp/SetupLogIn.java
@@ -12,6 +12,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.Switch;
 
 /**
@@ -51,6 +53,14 @@ public class SetupLogIn extends Fragment {
         drawCircle(r, g, b);
         System.out.println(toggle);
         tb.setChecked(toggle);
+
+        RelativeLayout notification = (RelativeLayout) view.findViewById(R.id.notificationLayout);
+        if (toggle){
+            notification.setVisibility(LinearLayout.VISIBLE);
+        }else{
+            notification.setVisibility(LinearLayout.INVISIBLE);
+        }
+
         return view;
     }
 


### PR DESCRIPTION
Fixes an issue where, if notifications are turned off, when returning to
settings page the notifications settings are not hidden.
