### PR TITLE
Fixed issue #14

### DIFF
--- a/app/src/main/java/com/johnston/lmhapp/GetEpos.java
+++ b/app/src/main/java/com/johnston/lmhapp/GetEpos.java
@@ -229,10 +229,12 @@ public class GetEpos extends AsyncTask<Object, String, String[]> {
                 if (inputLine.contains("<td align=\"left\">")) {
                     transactionStart = inputLine.indexOf("<td align=\"left\">") + 17;
                     transaction = inputLine.substring(transactionStart, inputLine.indexOf("<", transactionStart));
+                    Character char1 = transaction.charAt(2);
+                    Character char2 = transaction.charAt(5);
                     if (transaction.contains("&#163;")) {
                         transaction = "02   " + transaction.replace("&#163;", "£") + " " + meal;
                         transactions.add(transaction);
-                    } else if (transaction.contains("/")) {
+                    } else if (char1.equals('/')&&char2.equals('/')) {
                         if (!lastDate.equals(transaction)) {
                             sameMeal = false;
                             lastDate = transaction;


### PR DESCRIPTION
Hot/Cold dessert now displays as intended.

To check for a date, we check it has a "/" in the 3rd and 6th place,
instead of just for a "/" anywhere.
